### PR TITLE
feat: add orphaned component detection on menu composition

### DIFF
--- a/extensions/v1/builder.js
+++ b/extensions/v1/builder.js
@@ -59,6 +59,27 @@ class MenuBuilder {
         }
     }
 
+    identifyOrphanedComponents(contentCatalog) {
+        const components = contentCatalog.getComponents().map(component => component.name);
+        this.menu.forEach(menuEntry => {
+            this.reduceComponents(menuEntry, module => {
+                const idx = components.indexOf(module);
+                if (idx > -1) {
+                    components.splice(idx, 1);
+                }
+            });
+        });
+        return components;
+    }
+
+    reduceComponents(menuEntry, fnHandler) {
+        if(menuEntry.module) {
+            fnHandler(menuEntry.module);
+        } else if(menuEntry.entries) {
+            menuEntry.entries.forEach(entry => this.reduceComponents(entry, fnHandler))
+        }
+    }
+
     build(contentCatalog) {
         // resolved menu template
         const mainMenuContent = new MenuContent(this.hbs.groupStart, this.hbs.groupEnd, this.hbs.docRef);

--- a/extensions/v1/index.js
+++ b/extensions/v1/index.js
@@ -19,6 +19,7 @@ class DynaMenuExtension {
     constructor(context, config) {
         ;(this.antoraContext) = context
             .on('contentAggregated', this.contentAggregated.bind(this))
+            .on('contentClassified', this.contentClassified.bind(this))
             .on('navigationBuilt', this.navigationBuilt.bind(this));
         this.logger = this.antoraContext.getLogger('main-menu-extension');
         this.builder = new MenuBuilder(config, this.logger);
@@ -27,6 +28,13 @@ class DynaMenuExtension {
 
     contentAggregated({playbook, siteCatalog, contentAggregate}) {
         this.builder.resolveMenuDefinition(contentAggregate);
+    }
+
+    contentClassified({playbook, siteAsciiDocConfig, siteCatalog, uiCatalog, contentCatalog}) {
+        const orphanedComponents = this.builder.identifyOrphanedComponents(contentCatalog);
+        if (orphanedComponents.length > 0) {
+            this.logger.warn(`orphaned components: ${orphanedComponents}`);
+        }
     }
 
     navigationBuilt({playbook, siteAsciiDocConfig, siteCatalog, uiCatalog, contentCatalog, navigationCatalog}) {


### PR DESCRIPTION
A warning is logged if components are detected in the aggregated content catalog, but referenced from the menu declaration