### PR TITLE
Feature/support component page entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,16 +85,29 @@ A **group** is defined as:
 ```
 Nested elements may be groups (again), component references and/or external links.
 
-A **component reference** is defined as:
+A **component start page reference** is defined as:
 
 ```yaml
 - module: <moduleId>
 ```
+where 
+* `<moduleId>` is the `name` value from the targeted `antora.yml` element. 
+
+A **component explicit page reference** is defined as:
+
+```yaml
+- module: <moduleId>
+  page: <pageFilePath>
+```
+
+where 
+* `<moduleId>` is the `name` value from the targeted `antora.yml` element and
+* `<pageFilePath>` is the relative filesystem path to the page file to target
 
 An **external link** is defined as:
 
 ```yaml
-- title: <link display tex>
+- title: <link display text>
   link: <target url>
 ```
 
@@ -109,6 +122,8 @@ antora:
             - module: product-A
             - title: Product Sub 1
               entries:
+                - module: product-A
+                  page: "modules/ROOT/pages/anotherPage.adoc"
                 - module: product-B
         - title: Help
           entries:
@@ -198,6 +213,8 @@ antora:
             - title: sub group
               entries:
                 - module: existing-module
+                - module: existing-module
+                  page: "modules/ROOT/pages/sample.adoc"
                 - module: not-existing-module
                 - title: Antora Doc
                   link: https://docs.antora.org
@@ -208,9 +225,10 @@ The template `main-menu` is created by the extension as:
 ```handlebars
 {{> main-menu-group-start level=0 group_title="Products"}}
     {{> main-menu-group-start level=1 group_title="sub group"}}
-        {{> main-menu-docref resolved=true external=false ref="/existing-module/latest/<startpage of existing-module>.html" doc_title="<Title of existing-module>" component="<name of existing-module>"}}
-        {{> main-menu-docref resolved=false external=false ref="#" doc_title="not-existing-module" component="null"}}
-        {{> main-menu-docref resolved=true external=true ref="https://docs.antora.org" doc_title="Antora Doc"}}
+        {{> main-menu-docref resolved=true external=false ref="/existing-module/latest/<startpage of existing-module>.html" doc_title="<Title of existing-module>" component="<name of existing-module>" page=false}}
+        {{> main-menu-docref resolved=true external=false ref="/existing-module/latest/<sample>.html" doc_title="<Title of sample.adoc>" component="<name of existing-module>" page=true}}
+        {{> main-menu-docref resolved=false external=false ref="#" doc_title="not-existing-module" component="null" page=false}}
+        {{> main-menu-docref resolved=true external=true ref="https://docs.antora.org" doc_title="Antora Doc" component="null" page=false}}
     {{> main-menu-group-end}}
 {{> main-menu-group-end}}
 ```

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ A **component start page reference** is defined as:
 
 ```yaml
 - module: <moduleId>
+  title: "optional: override default title"
 ```
 where 
 * `<moduleId>` is the `name` value from the targeted `antora.yml` element. 
@@ -98,6 +99,7 @@ A **component explicit page reference** is defined as:
 ```yaml
 - module: <moduleId>
   page: <pageFilePath>
+  title: "optional: override default title"
 ```
 
 where 
@@ -197,7 +199,7 @@ The templates are supporting the following parameter:
   * Resolvable (either absolute or relative to playbook base) document URI.
   * The parameter contains `#`, if the parameter `resolved` is marked `false`.
 * `component`
-  * the components name (from antory.yml), if resolved, or `null` for unresolved module references and external links.
+  * the components name (from antora.yml), if resolved, or `null` for unresolved module references and external links.
 
 ### Sample
 

--- a/extensions/v1/builder.js
+++ b/extensions/v1/builder.js
@@ -107,11 +107,11 @@ class MenuBuilder {
                 });
                 let page = pages.find(()  => true);
                 return page
-                  ? Document.resolvedPage(page.asciidoc.doctitle, page.pub.url, component.name)
-                  : Document.resolved(component.latest.title, component.latest.url, component.name);
+                    ? Document.resolvedPage(entry.title ? entry.title : page.asciidoc.doctitle, page.pub.url, component.name)
+                    : Document.unresolvedPage(`${component.latest.title} (${entry.page})`, component.latest.url, component.name);
             }
             return component
-                ? Document.resolved(component.latest.title, component.latest.url, component.name)
+                ? Document.resolved(entry.title ? entry.title : component.latest.title, component.latest.url, component.name)
                 : Document.unresolved(entry.module);
         } else if(entry.title) {
             // group

--- a/extensions/v1/builder.js
+++ b/extensions/v1/builder.js
@@ -101,6 +101,15 @@ class MenuBuilder {
         } else if(entry.module) {
             // module reference
             const component = contentCatalog.getComponent(entry.module);
+            if(component && entry.page ) {
+                let pages = contentCatalog.getPages(p => {
+                    return p.src.path === entry.page;
+                });
+                let page = pages.find(()  => true);
+                return page
+                  ? Document.resolvedPage(page.asciidoc.doctitle, page.pub.url, component.name)
+                  : Document.resolved(component.latest.title, component.latest.url, component.name);
+            }
             return component
                 ? Document.resolved(component.latest.title, component.latest.url, component.name)
                 : Document.unresolved(entry.module);

--- a/extensions/v1/menuStructure.js
+++ b/extensions/v1/menuStructure.js
@@ -31,31 +31,37 @@ class Group extends Entry {
 class Document extends Entry {
     ref;
     resolved;
+    page;
     external;
     component;
 
     static external(title, ref) {
-        return new Document(title, ref, true, true, null);
+        return new Document(title, ref, true, true, false, null);
     }
 
     static resolved(title, ref, component) {
-        return new Document(title, ref, true, false, component);
+        return new Document(title, ref, true, false, false, component);
+    }
+
+    static resolvedPage(title, ref, component) {
+        return new Document(title, ref, true, false, true, component);
     }
 
     static unresolved(name) {
-        return new Document(name, "#", false, false, null);
+        return new Document(name, "#", false, false, false, null);
     }
 
-    constructor(title, ref, resolved = true, external = false, component = null) {
+    constructor(title, ref, resolved = true, external = false, page = false, component = null) {
         super(title);
         this.ref = ref;
         this.resolved = resolved;
         this.external = external;
+        this.page = page;
         this.component = component;
     }
 
     toString() {
-        return `Document(${this.title}${this.external ? " ,external" : ""}${this.resolved ? ", resolved" : ""},${this.ref})`
+        return `Document(${this.title}${this.external ? " ,external" : ""}${this.resolved ? ", resolved" : ""}${this.page ? ", page" : ""},${this.ref})`
     }
 }
 
@@ -96,7 +102,7 @@ class MenuContent {
     }
 
     link(entry) {
-        return `{{> ${this.hbsDocRef} resolved=${entry.resolved} doc_title="${entry.title}" ref="${entry.ref}" external=${entry.external} component="${entry.component}" }}`;
+        return `{{> ${this.hbsDocRef} resolved=${entry.resolved} doc_title="${entry.title}" ref="${entry.ref}" external=${entry.external} component="${entry.component}" page=${entry.page} }}`;
     }
 
     indent(level) {

--- a/extensions/v1/menuStructure.js
+++ b/extensions/v1/menuStructure.js
@@ -47,6 +47,10 @@ class Document extends Entry {
         return new Document(title, ref, true, false, true, component);
     }
 
+    static unresolvedPage(title, ref, component) {
+        return new Document(title, ref, false, false, true, component);
+    }
+
     static unresolved(name) {
         return new Document(name, "#", false, false, false, null);
     }


### PR DESCRIPTION
Menu entries for components use the start page as menu link target.

This MR allows optionally to reference a dedicated page in the component (instead of the start page).

```
  - module: existing-module
    page: "modules/ROOT/pages/sample.adoc"
```

This MR allows to override the menu entry text for component reference and page reference.

```
  - module: existing-module
    title: "custom module title"
```
or

```
  - module: existing-module
    page: "modules/ROOT/pages/sample.adoc"
    title: "custom page title"
```

